### PR TITLE
Add support for joystick events

### DIFF
--- a/resolver.py
+++ b/resolver.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import sys
-from sense_wrappers import sensors, led_matrix
+from sense_wrappers import sensors, led_matrix, joystick
 
 if "emulation" in sys.argv:
   from sense_emu import SenseHat
@@ -10,3 +10,4 @@ else:
 sense = SenseHat()
 sensors = sensors.Sensors(sense)
 led = led_matrix.LedMatrix(sense)
+joystick = joystick.Joystick(sense)

--- a/sense_wrappers/joystick.py
+++ b/sense_wrappers/joystick.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+class Joystick(object):
+  def __init__(self, sense):
+    self.__sense = sense
+
+  def get_events(self):
+    events = self.__sense.stick.get_events()[:1000]
+    return [self.__event_dict(event) for event in events]
+
+  def __event_dict(self, event):
+    return dict(event._asdict())

--- a/specification.yml
+++ b/specification.yml
@@ -212,6 +212,16 @@ paths:
         200:
           description: OK
 
+  /joystick/events:
+    get:
+      operationId: resolver.joystick.get_events
+      tags:
+       - Joystick
+      summary: Get joystick events since last call (max 1000)
+      responses:
+        200:
+          description: OK
+
 
 components:
   schemas:

--- a/tests/tavern_senseapi_v1/test_joystick.tavern.yaml
+++ b/tests/tavern_senseapi_v1/test_joystick.tavern.yaml
@@ -1,0 +1,10 @@
+test_name: SenseHAT Joystick
+
+stages:
+  - name: Humidity
+    request:
+      url: http://127.0.0.1:8000/senseapi/v1/joystick/events
+      method: GET
+    response:
+      status_code: 200
+      body: []


### PR DESCRIPTION
Adding support for getting joystick events. Seeing how the whole idea of this project is to be a wrapper for the default SenseHat library (e.g. I don't plan on adding a DB) adding support for Joystick events webhooks will be considered in the future, seeing how [the SenseHat library has a pretty solid base for implementing this](https://pythonhosted.org/sense-hat/api/#wait_for_event).