### PR TITLE
Pin to Raspbian Stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM balenalib/rpi-raspbian
+FROM balenalib/rpi-raspbian:stretch
 LABEL maintainer="Gabriel Tanase <tanase.gabriel91@gmail.com>"
 
 # Installing system dependencies


### PR DESCRIPTION
The base image was updated to `Buster` and `RTIMUlib` builds are failing:

```
Running setup.py clean for RTIMULib
ERROR: Complete output from command /sense-api/bin/python3 -u -c 'import setuptools, tokenize;__file__='"'"'/tmp/pip-install-0vufqfpj/RTIMULib/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-ktmigc4f --python-tag cp37:
ERROR: running bdist_wheel
running build
running build_ext
building 'RTIMU' extension
creating build
creating build/temp.linux-armv6l-3.7
creating RTIMULib
creating RTIMULib/IMUDrivers
arm-linux-gnueabihf-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DHAL_QUIET -I../../RTIMULib -I/usr/include/python3.7m -I/sense-api/include/python3.7m -c PyRTIMU.cpp -o build/temp.linux-armv6l-3.7/PyRTIMU.o -std=c++0x
unable to execute 'arm-linux-gnueabihf-gcc': No such file or directory
error: command 'arm-linux-gnueabihf-gcc' failed with exit status 1
```

I'm not entirely sure as to why this happens just yet, but https://github.com/kleinee/jns/issues/39 seems to provide an explanation. Note that after installing `arm-linux-gnueabihf-gcc`, the builds were still failing locally:

```
  PyRTIMU.cpp:28:10: fatal error: PyRTIMU.h: No such file or directory
   #include "PyRTIMU.h"
            ^~~~~~~~~~~
  compilation terminated.
  error: command 'arm-linux-gnueabihf-gcc' failed with exit status 1
```

Pinning to `Stretch` as an interim fix.