### PR TITLE
Don't install RTIMUlib from PyPI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,29 @@
-FROM balenalib/rpi-raspbian:stretch
+FROM balenalib/rpi-raspbian as intermediate
+
+# Cloning the RTIMUlib repository
+RUN apt-get update -y && apt-get install -y git
+RUN git clone https://github.com/RPi-Distro/RTIMULib
+
+FROM balenalib/rpi-raspbian
 LABEL maintainer="Gabriel Tanase <tanase.gabriel91@gmail.com>"
 
 # Installing system dependencies
 RUN apt-get update &&\
-    apt-get install -y --no-install-recommends python3 python3-virtualenv libatlas-base-dev libopenjp2-7 libtiff5
+    apt-get install -y --no-install-recommends\
+    python3 python3-dev python3-virtualenv g++ gcc-arm-linux-gnueabihf libatlas-base-dev libopenjp2-7 libtiff5
 
 # Setting up the virtualenv
 ENV VIRTUAL_ENV=/sense-api
 RUN python3 -m virtualenv --python=/usr/bin/python3 $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ADD . / sense-api/
+
+# Installing RTIMUlib
+COPY --from=intermediate /RTIMULib /RTIMULib
+WORKDIR /RTIMULib/Linux/python/
+RUN python setup.py build &&\
+    python setup.py install
+RUN rm -rf /RTIMULib
 
 # Installing dependencies and setting up gunicorn
 WORKDIR /sense-api

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,6 @@ python-box==3.4.1
 python-dateutil==2.8.0
 PyYAML==5.1.1
 requests==2.22.0
-RTIMULib==7.2.1
 sense-emu==1.1
 sense-hat==2.2.0
 six==1.12.0


### PR DESCRIPTION
Raspbian Buster introduces Python 3.7, for which RTIMUlib is not available through PyPI (see https://github.com/tanasegabriel/sense-api/pull/5).

In order to overcome this, RTIMULib must be built from source. This introduces 3 new dependencies - `python3-dev`, `g++` and  `gcc-arm-linux-gnueabihf`.

The [RTIMUlib repo](https://github.com/RTIMULib) is cloned in an intermediate container and copied to the build one, to avoid a large increase in the image.

While this is not ideal, it can be revised once / if a newer version of [RTIMUlib](https://pypi.org/project/RTIMULib/) supporting Python 3.7 is released.