### PR TITLE
Install RTIMULib from PyPi again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,15 @@
-FROM balenalib/rpi-raspbian as intermediate
-
-# Cloning the RTIMUlib repository
-RUN install_packages git &&\
-    git clone https://github.com/RPi-Distro/RTIMULib
-
 FROM balenalib/rpi-raspbian
 LABEL maintainer="Gabriel Tanase <tanase.gabriel91@gmail.com>"
 
 # Installing system dependencies
 RUN install_packages\
-    python3 python3-dev python3-virtualenv g++ gcc-arm-linux-gnueabihf libatlas-base-dev libopenjp2-7 libtiff5
+    python3 python3-virtualenv libatlas-base-dev libopenjp2-7 libtiff5
 
 # Setting up the virtualenv
 ENV VIRTUAL_ENV=/sense-api
 RUN python3 -m virtualenv --python=/usr/bin/python3 $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ADD . / sense-api/
-
-# Installing RTIMUlib
-COPY --from=intermediate /RTIMULib /RTIMULib
-WORKDIR /RTIMULib/Linux/python/
-RUN python setup.py build &&\
-    python setup.py install
-RUN rm -rf /RTIMULib
 
 # Installing dependencies and setting up gunicorn
 WORKDIR /sense-api

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ python-box==3.4.1
 python-dateutil==2.8.0
 PyYAML==5.1.1
 requests==2.22.0
+RTIMULib==7.2.1
 sense-emu==1.1
 sense-hat==2.2.0
 six==1.12.0


### PR DESCRIPTION
In https://github.com/tanasegabriel/sense-api/pull/6 building `RTIMULib` from source was adopted, as it was not available through `PyPi` for Raspbian Buster. This has changed:

```
root@1a60b405b95f:/# cat /etc/os-release
PRETTY_NAME="Raspbian GNU/Linux 10 (buster)"
NAME="Raspbian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
VERSION_CODENAME=buster
ID=raspbian
ID_LIKE=debian
HOME_URL="http://www.raspbian.org/"
SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"
root@1a60b405b95f:/# uname -r
4.15.0-62-generic
root@1a60b405b95f:/#
root@1a60b405b95f:/#
root@1a60b405b95f:/# pip install RTIMULib
Looking in indexes: https://pypi.org/simple, https://www.piwheels.org/simple
Collecting RTIMULib
  Downloading https://www.piwheels.org/simple/rtimulib/RTIMULib-7.2.1-cp37-cp37m-linux_armv6l.whl (383kB)
     |████████████████████████████████| 389kB 1.8MB/s
Installing collected packages: RTIMULib
Successfully installed RTIMULib-7.2.1
```

Building from source is expensive for a Docker image.