### PR TITLE
Leverage Docker Hub caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,12 @@ LABEL maintainer="Gabriel Tanase <tanase.gabriel91@gmail.com>" \
 RUN install_packages \
     python3 python3-pip libatlas-base-dev libopenjp2-7 libtiff5
 
-# Setting up the app
-ADD . / sense-api/
+# Installing requirements
 WORKDIR /sense-api
+ADD requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt
+
+# Setting up the app
+ADD . .
 EXPOSE 8000
 CMD ["gunicorn", "-b", "0.0.0.0:8000", "senseapi"]

--- a/hooks/build
+++ b/hooks/build
@@ -3,4 +3,5 @@
 echo "[***] Build hook running"
 docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
              --build-arg VCS_REF=`git rev-parse --short HEAD` \
-	     -t $IMAGE_NAME .
+             --cache-from $IMAGE_NAME \
+             -t $IMAGE_NAME .


### PR DESCRIPTION
Docker Hub does not leverage build caching if hooks that do not specify it are used.
Also, moving the installation of `requirements.txt` up a bit in the Dockerfile. This file shouldn't change as often as the rest of the stuff, so this should keep them cached unless touched.