### PR TITLE
Return only floats for numeric sensor values

### DIFF
--- a/sense_wrappers/sensors.py
+++ b/sense_wrappers/sensors.py
@@ -44,6 +44,8 @@ class Sensors(object):
     return getattr(self, name)()
 
   def __u_v_dict(self, u, v):
+    if isinstance(v, int):
+      v = float(v)
+    elif isinstance(v, dict):
+      v = { key:float(value) for key,value in v.items() }
     return {"unit": u, "value": v}
-
-


### PR DESCRIPTION
Because the SenseHat fixture was recorded with a real-life device, sometimes the orientation sensor returns precisely 0 values, in which case the SenseHat API returns an integer rather than a float.

Because of this, the Orientation test is flakey:

```
E tavern.util.exceptions.TestFailError: Test 'Orientation' failed:
E - Value mismatch in body: Type of returned data was different than expected (expected["0"]["value"]["pitch"] = '<Tavern YAML sentinel for <class 'float'>>' (type = <class 'tavern.util.loader.FloatSentinel'>), actual["0"]["value"]["pitch"] = '0' (type = <class 'int'>))
/usr/local/lib/python3.7/dist-packages/tavern/_plugins/rest/response.py:195: TestFailError
```

Every integer sensor value should be casted into a float, for consistency reasons.